### PR TITLE
Fix the empty process list issue on non rooted android devices

### DIFF
--- a/taskmanagerd/src/main/cpp/taskmanagerd.cpp
+++ b/taskmanagerd/src/main/cpp/taskmanagerd.cpp
@@ -35,17 +35,18 @@ std::vector<int> listPids() {
     std::vector<int> pids;
     pids.reserve(256);
 
-    try {
-        for (const auto &entry : fs::directory_iterator("/proc")) {
+    for (const auto &entry : fs::directory_iterator("/proc")) {
+        // Fix to move the try catch block inside the loop
+        try {
             if (entry.is_directory()) {
                 std::string name = entry.path().filename();
                 if (std::regex_match(name, pid_regex)) {
                     pids.push_back(std::stoi(name));
                 }
             }
+        } catch (...) {
+        
         }
-    } catch (...) {
-
     }
     return pids;
 }


### PR DESCRIPTION
When directory iterator for /proc gets a permission error for an item, it gets caught by the try/catch bracket outside of the loop, which then immediately returns instead of continuing. This fix just moves it inside of the loop.

On non rooted devices, or at least on my Samsung phone, it receives this then returns an empty list.
`filesystem error: in posix_stat: failed to determine attributes for the specified path: Permission denied ["/proc/stlog"]`

This fixes #31 