### PR TITLE
Improve su detection by executing id command instead of which

### DIFF
--- a/app/src/main/java/com/rk/Daemon.kt
+++ b/app/src/main/java/com/rk/Daemon.kt
@@ -289,9 +289,8 @@ suspend fun startDaemon(
 
 suspend fun isSuInPath(): Boolean = withContext(Dispatchers.IO) {
     return@withContext try {
-        val process = Runtime.getRuntime().exec(arrayOf("which", "su"))
-        val result = process.inputStream.bufferedReader().readLine()
-        result != null
+        val process = Runtime.getRuntime().exec(arrayOf("su", "-c", "id"))
+        process.waitFor() == 0
     } catch (e: Exception) {
         false
     }


### PR DESCRIPTION
## Summary
Updated the `isSuInPath()` function to use a more reliable method for detecting superuser (su) availability on the system.

## Key Changes
- Changed from using `which su` command to executing `su -c id` command
- Updated detection logic from checking command output to checking process exit code
- The new approach directly attempts to execute a command with su privileges and verifies success via exit code (0 = success)

## Implementation Details
The previous implementation relied on the `which` command to locate the `su` binary and checked if output was returned. The new approach is more direct and reliable:
- Executes `su -c id` which attempts to run the `id` command with superuser privileges
- Uses `process.waitFor() == 0` to check if the command succeeded (exit code 0)
- This method better validates actual su functionality rather than just binary presence
- Maintains the same exception handling for robustness